### PR TITLE
Remove restriction for workflow manager started while submitting task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.nirmata.workflow</groupId>
     <artifactId>nirmata-workflow</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 
     <properties>
         <jdk-version>17</jdk-version>

--- a/src/main/java/com/nirmata/workflow/details/WorkflowManagerKafkaImpl.java
+++ b/src/main/java/com/nirmata/workflow/details/WorkflowManagerKafkaImpl.java
@@ -195,7 +195,9 @@ public class WorkflowManagerKafkaImpl implements WorkflowManager, WorkflowAdmin 
 
     @Override
     public RunId submitSubTask(RunId runId, RunId parentRunId, Task task) {
-        Preconditions.checkState(state.get() == State.STARTED, "Not started");
+        // Not checking state since we need to submit jobs without starting
+        // workflows for NDEV-17000 
+        //Preconditions.checkState(state.get() == State.STARTED, "Not started");
 
         RunnableTaskDagBuilder builder = new RunnableTaskDagBuilder(task);
         Map<TaskId, ExecutableTask> tasks = builder


### PR DESCRIPTION
The workflow manager needs to be started in order to submit a task. However, we could have situations where a workflow is submitted from a service (E.g. Environments). But that service itself does not have a workflow manager. It is running in some other service (e.g. Environments-processor)